### PR TITLE
Helper classname does not follow conventions

### DIFF
--- a/views/helpers/tiny_mce.php
+++ b/views/helpers/tiny_mce.php
@@ -16,7 +16,7 @@
  * @subpackage tiny_m_c_e.views.helpers
  */
 
-class TinymceHelper extends AppHelper {
+class TinyMceHelper extends AppHelper {
 
 /**
  * Other helpers used by FormHelper


### PR DESCRIPTION
Helper class names should be the humanized version of the filename. The helper classname is `Tinymce`, and all usage documentation shows that it should be `TinyMce`, which follows the filename `tiny_mce.php`. This commit renames the classname to `TinyMce`.
