### PR TITLE
Trailing comma in options list vs Internet Explorer

### DIFF
--- a/views/helpers/tiny_mce.php
+++ b/views/helpers/tiny_mce.php
@@ -69,7 +69,10 @@ class TinymceHelper extends AppHelper {
 		foreach ($options as $option => $value) {
 			$lines .= Inflector::underscore($option) . ' : "' . $value . '",' . "\n";
 		}
-		$this->Html->scriptBlock('tinyMCE.init({' . "\n" . $lines . '});' . "\n", array(
+		// remove last comma from lines to avoid the editor breaking in Internet Explorer
+		$lines = rtrim($lines);
+		$lines = rtrim($lines, ',');
+		$this->Html->scriptBlock('tinyMCE.init({' . "\n" . $lines . "\n" . '});' . "\n", array(
 			'inline' => false));
 	}
 


### PR DESCRIPTION
Removed last comma in options list to avoid breakage of TinyMCE plugin in Internet Explorer.

Fixes the "Traling comma of death" issue. http://www.enterprisedojo.com/2010/12/19/beware-the-trailing-comma-of-death/
