### PR TITLE
Strict error PHP 5.4

### DIFF
--- a/View/Helper/TinyMCEHelper.php
+++ b/View/Helper/TinyMCEHelper.php
@@ -85,7 +85,7 @@ class TinyMCEHelper extends AppHelper {
  *
  * @return void
  */
-	public function beforeRender() {
+	public function beforeRender($viewFile) {
 		$appOptions = Configure::read('TinyMCE.editorOptions');
 		if ($appOptions !== false && is_array($appOptions)) {
 			$this->_defaults = $appOptions;


### PR DESCRIPTION
In PHP 5.4 shows up a strict error about before render, as this method does not have the same interface of Helper.php It was missing the viewFile param
