### PR TITLE
Strict error PHP 5.4

### DIFF
--- a/View/Helper/TinyMCEHelper.php
+++ b/View/Helper/TinyMCEHelper.php
@@ -82,10 +82,12 @@ class TinyMCEHelper extends AppHelper {
 
 /**
  * beforeRender callback
- *
+ * 
+ * @param string $viewFile The view file that is going to be rendered
+ * 
  * @return void
  */
-	public function beforeRender() {
+	public function beforeRender($viewFile) {
 		$appOptions = Configure::read('TinyMCE.editorOptions');
 		if ($appOptions !== false && is_array($appOptions)) {
 			$this->_defaults = $appOptions;


### PR DESCRIPTION
In PHP 5.4 the strict error is showing in beforeRender, it is because this method does not have the same interface of Helper.php It was missing the $viewFile param
