### PR TITLE
Added viewFile parameter to beforeRender

### DIFF
--- a/View/Helper/TinyMCEHelper.php
+++ b/View/Helper/TinyMCEHelper.php
@@ -85,7 +85,7 @@ class TinyMCEHelper extends AppHelper {
  *
  * @return void
  */
-	public function beforeRender() {
+	public function beforeRender($viewFile) {
 		$appOptions = Configure::read('TinyMCE.editorOptions');
 		if ($appOptions !== false && is_array($appOptions)) {
 			$this->_defaults = $appOptions;


### PR DESCRIPTION
Lack of this parameter throws strict standards error:
Strict (2048): Declaration of TinyMCEHelper::beforeRender() should be compatible with Helper::beforeRender($viewFile) [APP/Plugin/TinyMCE/View/Helper/TinyMCEHelper.php, line 95]
