### PR TITLE
Tweaked TinyMCEHelper

### DIFF
--- a/View/Helper/TinyMCEHelper.php
+++ b/View/Helper/TinyMCEHelper.php
@@ -40,6 +40,13 @@ class TinyMCEHelper extends AppHelper {
 	protected $_defaults = array();
 
 /**
+ * No editor class holder
+ *
+ * @var string
+ */
+	protected $_noEditorClass = 'mceNoEditor';
+
+/**
  * Constructor
  *
  * @param View $View The View this helper is being attached to.
@@ -47,10 +54,13 @@ class TinyMCEHelper extends AppHelper {
  */
 	public function __construct(View $View, $settings = array()) {
 		parent::__construct($View, $settings);
-		$configs = Configure::read('TinyMCE.configs');
+		$configs = Configure::read('Plugins.TinyMCE.configs');
 		if (!empty($configs) && is_array($configs)) {
 			$this->configs = $configs;
 		}
+
+		// Add no editor class to defaults
+		$this->noEditorClass($this->_noEditorClass);
 	}
 
 /**
@@ -58,15 +68,24 @@ class TinyMCEHelper extends AppHelper {
  *
  * @see http://www.tinymce.com/wiki.php/Configuration for a list of keys
  * @param mixed If array camel cased TinyMCE Init config keys, if string it checks if a config with that name exists
+ * @param boolean $scriptBlock Whether or not the result of this method is put in a scriptBlock
+ * @param boolean $inline Whether or not the scriptBlock should be inline or not
  * @return void
  */
-	public function editor($options = array()) {
+	public function editor($options = array(), $scriptBlock = true, $inline = false) {
 		if (is_string($options)) {
 			if (isset($this->configs[$options])) {
 				$options = $this->configs[$options];
 			} else {
 				throw new OutOfBoundsException(sprintf(__('Invalid TinyMCE configuration preset %s'), $options));
 			}
+		} elseif (isset($options['config'])) {
+			if (isset($this->configs[$options['config']])) {
+				$options = array_merge_recursive($this->configs[$options['config']], $options);
+			} else {
+				throw new OutOfBoundsException(sprintf(__('Invalid TinyMCE configuration preset %s'), $options['config']));
+			}
+			unset($options['config']);
 		}
 		$options = array_merge($this->_defaults, $options);
 		$lines = '';
@@ -77,7 +96,13 @@ class TinyMCEHelper extends AppHelper {
 		// remove last comma from lines to avoid the editor breaking in Internet Explorer
 		$lines = rtrim($lines);
 		$lines = rtrim($lines, ',');
-		$this->Html->scriptBlock('tinymce.init({' . "\n" . $lines . "\n" . '});' . "\n", array('inline' => false));
+		$result = 'tinymce.init({' . "\n" . $lines . "\n" . '});' . "\n";
+		if($scriptBlock){
+			return $this->Html->scriptBlock($result, array('inline' => $inline));
+		}
+		else{
+			return $result;
+		}
 	}
 
 /**
@@ -86,10 +111,26 @@ class TinyMCEHelper extends AppHelper {
  * @return void
  */
 	public function beforeRender($viewFile) {
-		$appOptions = Configure::read('TinyMCE.editorOptions');
+		$appOptions = Configure::read('Plugins.TinyMCE.editorOptions');
 		if ($appOptions !== false && is_array($appOptions)) {
 			$this->_defaults = $appOptions;
 		}
 		$this->Html->script('/TinyMCE/js/tiny_mce/tiny_mce.js', array('inline' => false));
 	}
+
+/**
+ * Setter/Getter for no editor class.
+ * Be carefull when using regex here. You can not use it a class getter then.
+ *
+ * @param string $class The class to use.
+ * @return string
+ */
+	public function noEditorClass($class = null){
+		if(!empty($class)){
+			$this->_noEditorClass = $class;
+			$this->_defaults['editor_deselector'] = $this->_noEditorClass;
+		}
+		return $this->_noEditorClass;
+	}
+
 }


### PR DESCRIPTION
Hey,

thanks for your plugin. 
I found it a great way to include TinyMCE, but I needed some changes in the code and thought they may be come in handy for ohters.

**Made it possible to load a config AND apply additional settings for the editor (usefull for language settings)**
Like already said, language setting is a great proof of concept for this one. Magic takes places in the TinyMCEHelper::editor() method.

**Made it possible to return the tinyMCE javascript code as a string or as an inline script block**
 I forgot that one in the commit comment, but it helped me out since I wanted to wrap the whole thing in another javascript method which is called on demand to spare some memory on client side.

**Added method to manage the no editor class**
 Like mentioned above I wrapped the whole thing in a javascript method. I needed to exclude some textareas and wanted to keep things centralized.
The whole getting method works with single classes only. Since it is centralized regex won't be needed anyway, so I think this is fine.

**Changed config paths**
 This is kind of a personal thing. I want to keep things as identifiable as possible. So I created another array called "Plugins" in the configuration to store plugin configuration in there.

Discuss ^^

Greetings
func0der
