### PR TITLE
Update TinyMCEHelper.php

### DIFF
--- a/View/Helper/TinyMCEHelper.php
+++ b/View/Helper/TinyMCEHelper.php
@@ -72,7 +72,11 @@ class TinyMCEHelper extends AppHelper {
 		$lines = '';
 
 		foreach ($options as $option => $value) {
-			$lines .= Inflector::underscore($option) . ' : "' . $value . '",' . "\n";
+			if (is_array($value) && isset($value['function'])) {
+				$lines .= $option . ' : ' . $value['function'] . ',' . "\n";
+			} else {
+				$lines .= Inflector::underscore($option) . ' : "' . $value . '",' . "\n";
+			}
 		}
 		// remove last comma from lines to avoid the editor breaking in Internet Explorer
 		$lines = rtrim($lines);


### PR DESCRIPTION
Add feature that allows to pass a function in configuration.

This is needed for file browser callback - since it's not passed as a string anymore:
'file_browser_callback' => array('function' => 'function myBrowser (field_name, url, type, win) {...}')
