### PR TITLE
[3.x] Requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 env:
   global:
@@ -16,13 +19,22 @@ env:
 
 matrix:
   include:
-    - php: 5.3
+    - php: 5.6
       env:
         - CAKE_VERSION=master
-    - php: 5.4
+    - php: 7.0
       env:
         - CAKE_VERSION=master
-    - php: 5.5
+    - php: 7.1
+      env:
+        - CAKE_VERSION=master
+    - php: 7.2
+      env:
+        - CAKE_VERSION=master
+    - php: 7.3
+      env:
+        - CAKE_VERSION=master
+    - php: 7.4
       env:
         - CAKE_VERSION=master
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The purpose of placing TinyMCE in a plugin is to keep it separate from a themed 
 Requirements
 ------------
 
-* CakePHP 2.5+
-* PHP 5.2.8+
+* CakePHP 3.0+
+* PHP 5.6+
 
 Documentation
 -------------

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/CakeDC/TinyMCE"
     },
     "require": {
-        "php": ">=5.2.8",
+        "php": ">=5.6.0",
         "cakephp/plugin-installer": "*"
     },
     "require-dev": {


### PR DESCRIPTION
The configured & documented requirements and the Travis build matrix were totally outdated.

The Travis config probably doesn't work, but at least it's more up to date than before.