### PR TITLE
[3.x] Composer 2.0 Deprecations

### DIFF
--- a/tests/TestCase/AllTinyMCETest.php
+++ b/tests/TestCase/AllTinyMCETest.php
@@ -10,7 +10,7 @@ namespace TinyMCE\Test\TestCase;
  * @copyright Copyright 2010 - 2014, Cake Development Corporation (http://cakedc.com)
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class AllTinyMcePluginTest extends PHPUnit_Framework_TestSuite
+class AllTinyMCETest extends PHPUnit_Framework_TestSuite
 {
 
     /**

--- a/tests/TestCase/View/Helper/TinyMCEHelperTest.php
+++ b/tests/TestCase/View/Helper/TinyMCEHelperTest.php
@@ -51,7 +51,7 @@ class TheTinyMCETestController extends Controller
  *
  * @package       TinyMCE.Test.Case.View.Helper
  */
-class TinyMCETest extends TestCase
+class TinyMCEHelperTest extends TestCase
 {
 
     /**

--- a/tests/TestCase/View/Helper/TinyMCEHelperTest.php
+++ b/tests/TestCase/View/Helper/TinyMCEHelperTest.php
@@ -24,29 +24,6 @@ use TinyMCE\View\Helper\TinyMCEHelper;
  */
 
 /**
- * TheTinyMceTestController class
- *
- * @package       TinyMce.Test.Case.View.Helper
- */
-class TheTinyMCETestController extends Controller
-{
-
-    /**
-     * name property
-     *
-     * @var string 'TheTest'
-     */
-    public $name = 'TheTest';
-
-    /**
-     * uses property
-     *
-     * @var mixed null
-     */
-    public $uses = null;
-}
-
-/**
  * TinyMCEHelperTest class
  *
  * @package       TinyMCE.Test.Case.View.Helper


### PR DESCRIPTION
Should fix the following warnings through Composer 1.x:
````
Deprecation Notice: Class TinyMCE\Test\TestCase\AllTinyMcePluginTest located in /path/to/app/vendor/cakedc/tiny-mce/tests\TestCase\AllTinyMCETest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar://C:/ProgramData/Composer/bin/composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class TinyMCE\Test\TestCase\View\Helper\TheTinyMCETestController located in /path/to/app/vendor/cakedc/tiny-mce/tests\TestCase\View\Helper\TinyMceHelperTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar://C:/ProgramData/Composer/bin/composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class TinyMCE\Test\TestCase\View\Helper\TinyMCETest located in /path/to/app/vendor/cakedc/tiny-mce/tests\TestCase\View\Helper\TinyMceHelperTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar://C:/ProgramData/Composer/bin/composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201
````