### PR TITLE
Fix type error in TinyMCEHelper::beforeRender()

### DIFF
--- a/src/View/Helper/TinyMCEHelper.php
+++ b/src/View/Helper/TinyMCEHelper.php
@@ -120,7 +120,7 @@ class TinyMCEHelper extends Helper
     /**
      * beforeRender callback
      *
-     * @param Event $event Ignored
+     * @param \Cake\Event\Event $event Ignored
      * @return void
      */
     public function beforeRender(Event $event): void

--- a/src/View/Helper/TinyMCEHelper.php
+++ b/src/View/Helper/TinyMCEHelper.php
@@ -119,10 +119,10 @@ class TinyMCEHelper extends Helper
     /**
      * beforeRender callback
      *
-     * @param string $viewFile The view file that is going to be rendered
+     * @param Event $event Ignored
      * @return void
      */
-    public function beforeRender(string $viewFile): void
+    public function beforeRender(Event $event): void
     {
         $appOptions = Configure::read('TinyMCE.editorOptions');
         if ($appOptions !== false && is_array($appOptions)) {

--- a/src/View/Helper/TinyMCEHelper.php
+++ b/src/View/Helper/TinyMCEHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace TinyMCE\View\Helper;
 
 use Cake\Core\Configure;
+use Cake\Event\Event;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\View;

--- a/tests/TestCase/View/Helper/TinyMceHelperTest.php
+++ b/tests/TestCase/View/Helper/TinyMceHelperTest.php
@@ -133,7 +133,6 @@ theme : "modern"
 TINYMCE,
                 ['block' => true]
             );
-        $this->TinyMCE->beforeRender('test.ctp');
         $this->TinyMCE->editor(['theme' => 'modern']);
     }
 
@@ -170,6 +169,5 @@ TINYMCE,
                 'https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js',
                 ['block' => true, 'referrerpolicy' => true]
             );
-        $this->TinyMCE->beforeRender('test.ctp');
     }
 }


### PR DESCRIPTION
Fix for: 
[TypeError] TinyMCE\View\Helper\TinyMCEHelper::beforeRender(): Argument #1 ($viewFile) must be of type TinyMCE\View\Helper\Event, Cake\Event\Event given, called in /web/GenericConference/vendor/cakephp/cakephp/src/Event/EventManager.php on line 329 in /web/GenericConference/vendor/cakedc/tiny-mce/src/View/Helper/TinyMCEHelper.php on line 125